### PR TITLE
Set local

### DIFF
--- a/src/Infra/System.php
+++ b/src/Infra/System.php
@@ -42,7 +42,7 @@ class System
 
     public function timezone() : string
     {
-        $time = shell_exec('date');
+        $time = shell_exec('export LC_ALL=en;date');
         $date = new DateTimeImmutable($time);
         $zone = $date->getTimeZone()->getName();
         switch ($zone) {


### PR DESCRIPTION
In my machine (OSX), `date` produce in Japanese format.

```
% date
2020年 12月26日 土曜日 02時00分11秒 JST
```

When I set the locale, the output is in English.

```
% export LC_ALL=en; date
Sat Dec 26 02:01:12 JST 2020
```